### PR TITLE
Ignore Swift protocols

### DIFF
--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -65,9 +65,6 @@
         return nil;
     CDOCProtocol *protocol = [self.protocolUniquer protocolWithAddress:address];
     if (protocol == nil) {
-        protocol = [[CDOCProtocol alloc] init];
-        [self.protocolUniquer setProtocol:protocol withAddress:address];
-        
         CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithFile:self.machOFile address:address];
         if ([cursor offset] == -'S') {
             NSLog(@"Warning: Meet Swift object at %s",__cmd);
@@ -101,6 +98,7 @@
         //NSLog(@"%016lx %016lx %016lx %016lx", objc2Protocol.isa, objc2Protocol.name, objc2Protocol.protocols, objc2Protocol.instanceMethods);
         //NSLog(@"%016lx %016lx %016lx %016lx", objc2Protocol.classMethods, objc2Protocol.optionalInstanceMethods, objc2Protocol.optionalClassMethods, objc2Protocol.instanceProperties);
         
+        protocol = [[CDOCProtocol alloc] init];
         NSString *str = [self.machOFile stringAtAddress:objc2Protocol.name];
         [protocol setName:str];
         
@@ -133,7 +131,7 @@
         for (CDOCProperty *property in [self loadPropertiesAtAddress:objc2Protocol.instanceProperties])
             [protocol addProperty:property];
     }
-    
+    [self.protocolUniquer setProtocol:protocol withAddress:address];
     return protocol;
 }
 

--- a/Source/CDProtocolUniquer.m
+++ b/Source/CDProtocolUniquer.m
@@ -51,6 +51,7 @@
     
     for (NSNumber *key in [[_protocolsByAddress allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
         CDOCProtocol *p1 = _protocolsByAddress[key];
+        NSAssert(p1.name != nil, @"[CDOCProtocol name] should not be nil at this point.");
         CDOCProtocol *uniqueProtocol = _uniqueProtocolsByName[p1.name];
         if (uniqueProtocol == nil) {
             uniqueProtocol = [[CDOCProtocol alloc] init];

--- a/UnitTests/TestCDProtocolUniquer.m
+++ b/UnitTests/TestCDProtocolUniquer.m
@@ -1,0 +1,33 @@
+//
+//  TestCDProtocolUniquer.m
+//  UnitTests
+//
+//  Created by Ryosuke Ito on 5/6/23.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CDProtocolUniquer.h"
+#import "CDOCProtocol.h"
+
+@interface TestCDProtocolUniquer : XCTestCase
+@end
+
+@implementation TestCDProtocolUniquer
+
+- (void)test_createUniquedProtocols_withNoProtocols {
+    CDProtocolUniquer *uniquer = [[CDProtocolUniquer alloc] init];
+    [uniquer createUniquedProtocols];
+    XCTAssertEqual(uniquer.uniqueProtocolsSortedByName.count, 0);
+}
+
+- (void)test_createUniquedProtocols_withProtocol {
+    CDProtocolUniquer *uniquer = [[CDProtocolUniquer alloc] init];
+    CDOCProtocol *protocol = [[CDOCProtocol alloc] init];
+    protocol.name = @"Foo";
+    [uniquer setProtocol:protocol withAddress:0x8];
+    [uniquer createUniquedProtocols];
+    XCTAssertEqual(uniquer.uniqueProtocolsSortedByName.count, 1);
+}
+
+@end

--- a/class-dump.xcodeproj/project.pbxproj
+++ b/class-dump.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		01FB2152222A86C40012A5D3 /* blowfish.c in Sources */ = {isa = PBXBuildFile; fileRef = 01FB2150222A86C40012A5D3 /* blowfish.c */; };
 		0D288C10187BC2EE0026E2A0 /* CDOCClassReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D288C0E187BC2EE0026E2A0 /* CDOCClassReference.h */; };
 		0D288C11187BC2EE0026E2A0 /* CDOCClassReference.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D288C0F187BC2EE0026E2A0 /* CDOCClassReference.m */; };
+		5BACA6972A062B3200F40FC0 /* TestCDProtocolUniquer.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BACA6962A062B3200F40FC0 /* TestCDProtocolUniquer.m */; };
 		C270B5C616C54AD6006CA75D /* ULEB128.m in Sources */ = {isa = PBXBuildFile; fileRef = C270B5C516C54AD5006CA75D /* ULEB128.m */; };
 		C270B5C816C54B0C006CA75D /* ULEB128.h in Headers */ = {isa = PBXBuildFile; fileRef = C270B5C716C54B0A006CA75D /* ULEB128.h */; };
 /* End PBXBuildFile section */
@@ -401,6 +402,7 @@
 		01FB2150222A86C40012A5D3 /* blowfish.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = blowfish.c; path = ThirdParty/blowfish.c; sourceTree = "<group>"; };
 		0D288C0E187BC2EE0026E2A0 /* CDOCClassReference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDOCClassReference.h; path = Source/CDOCClassReference.h; sourceTree = "<group>"; };
 		0D288C0F187BC2EE0026E2A0 /* CDOCClassReference.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDOCClassReference.m; path = Source/CDOCClassReference.m; sourceTree = "<group>"; };
+		5BACA6962A062B3200F40FC0 /* TestCDProtocolUniquer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestCDProtocolUniquer.m; sourceTree = "<group>"; };
 		C270B5C516C54AD5006CA75D /* ULEB128.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ULEB128.m; path = Source/ULEB128.m; sourceTree = "<group>"; };
 		C270B5C716C54B0A006CA75D /* ULEB128.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ULEB128.h; path = Source/ULEB128.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -491,6 +493,7 @@
 				011E484E1604DF3700722F8D /* TestCDNameForCPUType.m */,
 				0165B8C91827198900CC647F /* TestCDArchFromName.m */,
 				0165B8CB1827198900CC647F /* TestCDArchUses64BitABI.m */,
+				5BACA6962A062B3200F40FC0 /* TestCDProtocolUniquer.m */,
 				0165B8CD1827198900CC647F /* TestFatFile_armv7_v7s.m */,
 				0165B8CF1827198900CC647F /* TestFatFile_Intel32_64_lib64.m */,
 				0165B8D11827198900CC647F /* TestFatFile_Intel32_64.m */,
@@ -1026,6 +1029,7 @@
 				0165B8D81827198900CC647F /* TestBlockSignature.m in Sources */,
 				0165B8DD1827198900CC647F /* TestFatFile_Intel32_64.m in Sources */,
 				0165B8DB1827198900CC647F /* TestFatFile_armv7_v7s.m in Sources */,
+				5BACA6972A062B3200F40FC0 /* TestCDProtocolUniquer.m in Sources */,
 				0165B8DA1827198900CC647F /* TestCDArchUses64BitABI.m in Sources */,
 				0165B8DC1827198900CC647F /* TestFatFile_Intel32_64_lib64.m in Sources */,
 				0165B8D91827198900CC647F /* TestCDArchFromName.m in Sources */,


### PR DESCRIPTION
- Add precondition check
- Add tests for CDProtocolUniquer
- Do not add no name protocol to uniquer
